### PR TITLE
adding software-properties-common so that we can add outside PPAs

### DIFF
--- a/run.bash
+++ b/run.bash
@@ -141,7 +141,7 @@ function check_support {
 function install_basic_deps {
     echo "Updating apt-get and installing basic dependencies (this could take a while)..."
     sudo apt-get update
-    sudo apt-get install jq screen curl mercurial git bzr redis-server python-software-properties -qqy
+    sudo apt-get install jq screen curl mercurial git bzr redis-server software-properties-common python-software-properties -qqy
     sudo apt-add-repository ppa:tsuru/ppa -y >/dev/null 2>&1
     sudo apt-get update
 }


### PR DESCRIPTION
Just a minor change to make the script work again. The software-properties-common is needed to be able to add the tsuru/pp repository with add-repository.
