### PR TITLE
Adds libz-dev package for swift installation

### DIFF
--- a/run.bash
+++ b/run.bash
@@ -423,7 +423,7 @@ function install_archive_server_src {
 }
 
 function install_swift {
-    sudo apt-get install python-pip python-dev libxml2-dev libxslt-dev -y
+    sudo apt-get install python-pip python-dev libxml2-dev libxslt-dev libz-dev -y
     sudo pip install python-swiftclient python-keystoneclient
 }
 


### PR DESCRIPTION
During the installation of python-keystoneclient the package lxml failed to install. The message I got was: 

/usr/bin/ld: cannot find -lz

Installing pacakge libz-dev helped prevent this.
