### PR TITLE
Stop processing script after showing help

### DIFF
--- a/run.bash
+++ b/run.bash
@@ -637,6 +637,7 @@ while [ "${1-}" != "" ]; do
             ;;
         * | "-h" | "--help")
             show_help
+            exit
             ;;
 
     esac


### PR DESCRIPTION
Minor fix that will stop the script after the help option is displayed (issued by -h / --help or an unknown parameter).
