### PR TITLE
Update urls in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ These are some goals for this project:
 Running the command below should already create a working tsuru environment:
 
 ```
-curl -sL https://raw.github.com/tsuru/now/master/run.bash | bash
+curl -sL https://raw.githubusercontent.com/tsuru/now/master/run.bash | bash
 ```
 
 ## Advanced Usage
@@ -28,7 +28,7 @@ With Tsuru Now, you can build your own tsuru cluster easily.
 ### Building a cluster server
 
 ```
-curl -sL https://raw.github.com/tsuru/now/master/run.bash > run.bash
+curl -sL https://raw.githubusercontent.com/tsuru/now/master/run.bash > run.bash
 chmod +x run.bash
 ./run.bash --template server
 ```
@@ -39,7 +39,7 @@ chmod +x run.bash
 Assume the IP address of cluster server is 10.42.42.1
 
 ```
-curl -sL https://raw.github.com/tsuru/now/master/run.bash > run.bash
+curl -sL https://raw.githubusercontent.com/tsuru/now/master/run.bash > run.bash
 chmod +x run.bash
 ./run.bash --template client --host-ip 10.42.42.1
 ```
@@ -50,7 +50,7 @@ chmod +x run.bash
 Assume the IP address of cluster server is 10.42.42.1
 
 ```
-curl -sL https://raw.github.com/tsuru/now/master/run.bash > run.bash
+curl -sL https://raw.githubusercontent.com/tsuru/now/master/run.bash > run.bash
 chmod +x run.bash
 ./run.bash --template dockerfarm --host-ip 10.42.42.1
 ```


### PR DESCRIPTION
The command in the readme file causes the following error due to the redirect;

```
bash: line 1: syntax error near unexpected token `newline'
bash: line 1: `<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">'
```

Updated the URLs in README.md to use raw.githubusercontent.com. 
