### PR TITLE
Fix local IP discovery on DigitalOcean

### DIFF
--- a/run.bash
+++ b/run.bash
@@ -172,6 +172,17 @@ function public_ip {
 function local_ip {
     # Try to take the public IP using AWS EC2's metadata API:
     local ip=$(curl -s -L -m2 http://169.254.169.254/latest/meta-data/local-ipv4 || true)
+    
+    # Try to use DigitalOcean's metadata API as fallback:
+    if [[ "$ip" == "" || "$ip" == "not found" ]]; then
+        ip=$(curl -s -L -m2 http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address || true)
+    fi
+    
+    # Fallback to localhost as last alternative
+    if [[ "$ip" == "" || "$ip" == "not found" ]]; then
+        ip=127.0.0.1
+    fi
+    
     echo "${ip}"
 }
 


### PR DESCRIPTION
Use DigitalOcean metadata discovery as a fallback from EC2 and as last resort 127.0.0.1.