### PR TITLE
Avoid reading garbage when cloud metadata URL returns error message

### DIFF
--- a/run.bash
+++ b/run.bash
@@ -140,11 +140,11 @@ function get_inet_addr() {
 
 function public_ip {
     # Try to take the public IP using AWS EC2's metadata API:
-    local ip=$(curl -s -L -m2 http://169.254.169.254/latest/meta-data/public-ipv4 || true)
+    local ip=$(curl -s -L -m2 -f http://169.254.169.254/latest/meta-data/public-ipv4 || true)
 
     # Try to use DigitalOcean's metadata API as fallback:
     if [[ "$ip" == "" || "$ip" == "not found" ]]; then
-        ip=$(curl -s -L -m2 http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address || true)
+        ip=$(curl -s -L -m2 -f http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address || true)
     fi
 
     # Try via ifconfig
@@ -174,11 +174,11 @@ function public_ip {
 
 function local_ip {
     # Try to take the public IP using AWS EC2's metadata API:
-    local ip=$(curl -s -L -m2 http://169.254.169.254/latest/meta-data/local-ipv4 || true)
+    local ip=$(curl -s -L -m2 -f http://169.254.169.254/latest/meta-data/local-ipv4 || true)
 
     # Try to use DigitalOcean's metadata API as fallback:
     if [[ "$ip" == "" || "$ip" == "not found" ]]; then
-        ip=$(curl -s -L -m2 http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address || true)
+        ip=$(curl -s -L -m2 -f http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address || true)
     fi
 
     if [[ "$ip" == "not found" ]]; then


### PR DESCRIPTION
This avoids polluting files such as /etc/hosts and /home/git/.bash_profile (and ultimately crashing) when your cloud provider has an unsupported metadata API in http://169.254.169.254/ which returns explicit error messages (e.g. IBM Bluemix).